### PR TITLE
Fix Scan postgres uuid

### DIFF
--- a/types.go
+++ b/types.go
@@ -128,7 +128,11 @@ func (o *Uuid) Scan(pSrc interface{}) error {
 		return o.UnmarshalText([]byte(src))
 
 	case []byte:
-		return o.UnmarshalBinary(src)
+		if len(src) == length {
+			return o.UnmarshalBinary(src)
+		} else {
+			return o.UnmarshalText(src)
+		}
 
 	default:
 		return fmt.Errorf("uuid.Uuid.Scan: cannot scan type %T into Uuid", pSrc)

--- a/types_test.go
+++ b/types_test.go
@@ -2,8 +2,9 @@ package uuid
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUuid_Bytes(t *testing.T) {
@@ -197,6 +198,11 @@ func TestUuid_Scan(t *testing.T) {
 	err = v.Scan(NameSpaceDNS.String())
 	assert.NoError(t, err, "When nil there should be no error")
 	assert.Equal(t, NameSpaceDNS.String(), v.String(), "Values should be the same")
+
+	var v3 Uuid
+	err = v3.Scan([]byte(NameSpaceDNS.String()))
+	assert.NoError(t, err, "When []byte represents string should be no error")
+	assert.Equal(t, NameSpaceDNS.String(), v3.String(), "Values should be the same")
 
 	err = v.Scan(22)
 	assert.Error(t, err, "When wrong type should error")


### PR DESCRIPTION
I use **postgres** model with uuid fields like:
```sql
CREATE TABLE person (
    id   UUID,
    name TEXT,

    PRIMARY KEY id
);
```
And **sqlx** model:
```go
type Person struct {
	Id    uuid.Uuid `db:"id"`
	Name  string    `db:"name"`
}
```

But when I try to get some model from db it's throwing an error:
```
Scan error on column index 0: uuid.Uuid.UnmarshalBinary:  invalid length
```

This is because **sqlx** runs the `Scan` method with `[]byte` representation of the `string` form of uuid. I don't know how to make **sqlx** or **sql** use `string` instead of `[]byte`. But you may check the length of `src` in the `Scan` method and run `UnmarshalBinary` only when the length is 16. Otherwise use `UnmarshalText`.